### PR TITLE
Use nodejs20, npm10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,11 @@
         "backlog-mcp-server": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "^18.0.0"
+        "@types/node": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -43,13 +47,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.86",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
-      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+      "version": "20.17.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
+      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/accepts": {
@@ -1089,9 +1093,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
     "typescript": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0"
+    "@types/node": "^20.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
+  "volta": {
+    "node": "20.19.1",
+    "npm": "10.9.2"
   }
 }


### PR DESCRIPTION
- npm:9の環境で下記のInstallがFailしていたため、node20,npm10を必須にしました
```
npx --verbose -y https://github.com/pj8/backlog-mcp-server
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 開発環境のNode.jsおよびnpmのバージョン要件を更新しました。
  - Node.jsとnpmのバージョン固定設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->