### PR TITLE
Check node,npm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "backlog-mcp-server": "build/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "check-engines": "npx check-node-version --node '>=20.0.0' --npm '>=10.0.0'",
+    "preprepare": "npm run check-engines",
     "prepare": "npm run build",
+    "build": "tsc",
     "start": "node build/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
- npxはversion指定を無視するため、`preprepare`でnode20以上,npm10以上をチェックする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Node.js（バージョン20.0.0以上）およびnpm（バージョン10.0.0以上）のバージョンチェックを自動で実行するスクリプトを追加しました。

- **その他**
  - ビルド関連スクリプトの実行順序を一部調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->