### PR TITLE
Revert "Delete version check"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,16 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-      "integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.0.tgz",
+      "integrity": "sha512-wijOavYZfSOADbVM0LA7mrQ17N4IKNdFcfezknCCsZ1Y1KstVWlkDZ5ebcxuQJmqTTxsNjBHLc7it1SV0TBiPg==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -73,9 +77,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -1136,9 +1140,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "backlog-mcp-server": "build/index.js"
   },
   "scripts": {
+    "check-engines": "npx check-node-version --node '>=20.0.0' --npm '>=10.0.0'",
+    "preprepare": "npm run check-engines",
     "prepare": "npm run build",
     "build": "tsc",
     "start": "node build/index.js"
@@ -22,6 +24,10 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
   },
   "volta": {
     "node": "20.19.1",


### PR DESCRIPTION
- Reverts pj8/backlog-mcp-server#4
- #4 で、`form-data`の問題は解決したが、MCPサーバが起動しないため、node20以上,npm10以上を必須とします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Node.js（バージョン20.0.0以上）およびnpm（バージョン10.0.0以上）が必要となりました。
  - 環境のバージョンチェックが自動で実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->